### PR TITLE
fix: Fix malleable signature (SC-5066)

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -29,7 +29,8 @@ contract ERC20 is IERC20 {
     /****************/
 
     // PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 amount,uint256 nonce,uint256 deadline)");
-    bytes32 public constant override PERMIT_TYPEHASH = 0xfc77c2b9d30fe91687fd39abb7d16fcdfe1472d065740051ab8b13e4bf4a617f;
+    bytes32 public constant override PERMIT_TYPEHASH      = 0xfc77c2b9d30fe91687fd39abb7d16fcdfe1472d065740051ab8b13e4bf4a617f;
+    uint256 public constant S_VALUE_INCLUSIVE_UPPER_BOUND = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
 
     mapping (address => uint256) public override nonces;
 
@@ -72,6 +73,11 @@ contract ERC20 is IERC20 {
                 keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, amount, nonces[owner]++, deadline))
             )
         );
+
+        // Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (301): 0 < s < secp256k1n ÷ 2 + 1, and for v in (302): v ∈ {27, 28}.
+        require(uint256(s) <= S_VALUE_INCLUSIVE_UPPER_BOUND && (v == 27 || v == 28), "ERC20:P:MALLEABLE");
+
         address recoveredAddress = ecrecover(digest, v, r, s);
         require(recoveredAddress == owner && owner != address(0), "ERC20:P:INVALID_SIGNATURE");
         _approve(owner, spender, amount);

--- a/contracts/test/ERC20.t.sol
+++ b/contracts/test/ERC20.t.sol
@@ -299,9 +299,10 @@ contract ERC20PermitTest is TestUtils {
         uint256 amount = 10 * WAD;
         ( uint8 v, bytes32 r, bytes32 s ) = _getValidPermitSignature(amount, owner, skOwner, deadline);
 
-        // TODO: figure out why 255 does an arithmetic over/underflow.
-        for (uint8 i; i <= 254; i++) {
-            if (i == 28) {
+        for (uint8 i; i <= type(uint8).max; i++) {
+            if (i == type(uint8).max) {
+                break;
+            } else if (i == 28) {
                 continue;
             } else if (i == 27) {
                 // Should get past the Malleable require check as 27 or 28 are valid values for s.


### PR DESCRIPTION
Added to Permit:

// Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
// the valid range for s in (301): 0 < s < secp256k1n ÷ 2 + 1, and for v in (302): v ∈ {27, 28}.
`require(uint256(s) <= S_VALUE_INCLUSIVE_UPPER_BOUND && (v == 27 || v == 28), "ERC20:P:MALLEABLE");`

Addresses https://github.com/maple-labs/tob-audit-2022-03-07/issues/5