### PR TITLE
fix: test_permitBadV

### DIFF
--- a/contracts/test/ERC20.t.sol
+++ b/contracts/test/ERC20.t.sol
@@ -302,18 +302,20 @@ contract ERC20PermitTest is TestUtils {
         for (uint8 i; i <= type(uint8).max; i++) {
             if (i == type(uint8).max) {
                 break;
-            } else if (i == 28) {
-                continue;
-            } else if (i == 27) {
-                // Should get past the Malleable require check as 27 or 28 are valid values for s.
-                vm.expectRevert(bytes("ERC20:P:INVALID_SIGNATURE"));
-            } else {
+            } else if (i != 27 && i != 28) {
                 vm.expectRevert(bytes("ERC20:P:MALLEABLE"));
+            } else {
+                if (i == v) {
+                    continue;
+                } else {
+
+                    // Should get past the Malleable require check as 27 or 28 are valid values for s.
+                    vm.expectRevert(bytes("ERC20:P:INVALID_SIGNATURE"));
+                }
             }
             user.erc20_permit(address(token), owner, spender, amount, deadline, i, r, s);
         }
 
-        assertEq(v, 28);
         user.erc20_permit(address(token), owner, spender, amount, deadline, v, r, s);
     }
 

--- a/contracts/test/ERC20.t.sol
+++ b/contracts/test/ERC20.t.sol
@@ -297,6 +297,10 @@ contract ERC20PermitTest is TestUtils {
 
     function test_permitBadV() external {
         uint256 amount = 10 * WAD;
+
+        // Get valid signature. The `v` value is the expected v value that will cause `permit` to succeed, and must be 27 or 28.
+        // Any other value should fail. 
+        // If v is 27, then 28 should make it past the MALLEABLE require, but should result in an invalid signature, and vice versa when v is 28.
         ( uint8 v, bytes32 r, bytes32 s ) = _getValidPermitSignature(amount, owner, skOwner, deadline);
 
         for (uint8 i; i <= type(uint8).max; i++) {

--- a/contracts/test/ERC20.t.sol
+++ b/contracts/test/ERC20.t.sol
@@ -308,7 +308,6 @@ contract ERC20PermitTest is TestUtils {
                 if (i == v) {
                     continue;
                 } else {
-
                     // Should get past the Malleable require check as 27 or 28 are valid values for s.
                     vm.expectRevert(bytes("ERC20:P:INVALID_SIGNATURE"));
                 }


### PR DESCRIPTION
- fix test_permitBadV where tokens inheriting the erc20 test cases might have a different `v` value for the permit signature due to different `DOMAIN_SEPERATOR`