### PR TITLE
fix: C4 - Use fixed pragma (SC-5353)

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { IERC20 } from "./interfaces/IERC20.sol";
 

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 /// @title Interface of the ERC20 standard as defined in the EIP, including ERC-2612 permit functionality.
 interface IERC20 {

--- a/contracts/test/ERC20.t.sol
+++ b/contracts/test/ERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { InvariantTest, TestUtils } from "../../modules/contract-test-utils/contracts/test.sol";
 

--- a/contracts/test/accounts/ERC20User.sol
+++ b/contracts/test/accounts/ERC20User.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { IERC20 } from "../../interfaces/IERC20.sol";
 

--- a/contracts/test/mocks/MockERC20.sol
+++ b/contracts/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import { ERC20 } from "../../ERC20.sol";
 


### PR DESCRIPTION
# Description
Address C4 issue: https://github.com/code-423n4/2022-03-maple-findings/issues/14

Changed all floating pragmas to use `0.8.7`
