### PR TITLE
fix: C4 - Fix typos (SC-5350)

### DIFF
--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.7;
 
-/// @title Interface of the ERC20 standard as defined in the EIP, including ERC-2612 permit functionality.
+/// @title Interface of the ERC20 standard as defined in the EIP, including EIP-2612 permit functionality.
 interface IERC20 {
 
     /**************/

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -9,7 +9,7 @@ interface IERC20 {
     /**************/
 
     /**
-     *  @dev   Emits an event indicating that one account has set the allowance of another account over their tokens.
+     *  @dev   Emitted when one account has set the allowance of another account over their tokens.
      *  @param owner_   Account that tokens are approved from.
      *  @param spender_ Account that tokens are approved for.
      *  @param amount_  Amount of tokens that have been approved.
@@ -17,7 +17,7 @@ interface IERC20 {
     event Approval(address indexed owner_, address indexed spender_, uint256 amount_);
 
     /**
-     *  @dev   Emits an event indicating that tokens have moved from one account to another.
+     *  @dev   Emitted when tokens have moved from one account to another.
      *  @param owner_     Account that tokens have moved from.
      *  @param recipient_ Account that tokens have moved to.
      *  @param amount_    Amount of tokens that have been transferred.
@@ -126,10 +126,10 @@ interface IERC20 {
 
     /**
       *  @dev    Returns the nonce for the given owner.
-      *  @param  owner  The address of the owner account.
+      *  @param  owner_  The address of the owner account.
       *  @return nonce_ The nonce for the given owner.
      */
-    function nonces(address owner) external view returns (uint256 nonce_);
+    function nonces(address owner_) external view returns (uint256 nonce_);
 
     /**
      *  @dev    Returns the permit type hash.


### PR DESCRIPTION
# Description
Addresses C4 issue (typos section): https://github.com/code-423n4/2022-03-maple-findings/issues/17

Changed `owner` to `owner_`
Changed `Emits an event indicating that` to `Emitted when`
Changed `ERC 2612` to `EIP 2612`