### PR TITLE
build: set solidity version to ^0.8.7 on contracts

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.7;
+pragma solidity ^0.8.7;
 
 import { IERC20 } from "./interfaces/IERC20.sol";
 

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.7;
+pragma solidity ^0.8.7;
 
 /// @title Interface of the ERC20 standard as defined in the EIP, including EIP-2612 permit functionality.
 interface IERC20 {


### PR DESCRIPTION
# Description

The solidity version specified in the contracts are locked into `0.8.7`, this  prevents people from using this implementation if they want to use another version of the compiler. This change updates the compiler requirement to `^0.8.7`, allowing patch versions higher than 7. I'm assuming u need at least patch version 7 for some reason.

Got this problem when adding this implementation to [solidity-benchmarks](https://github.com/alephao/solidity-benchmarks)

# Integrations Checklist

- [x] Have any function signatures changed? If yes, outline below.
- [x] Have any features changed or been added? If yes, outline below.
- [x] Have any events changed or been added? If yes, outline below.
- [x] Has all documentation been updated?

# Changelog

* Set solidity version on contracts to `^0.8.7`